### PR TITLE
chore: drop net9.0, target net10.0 only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Please ADD ALL Changes to the UNRELEASED SECTION and not a specific release
 ### Changed
 ### Deprecated
 ### Removed
+- Removed net9.0 target framework; the library now targets net10.0 only
 ### Deployment Changes
 <!--
 Releases that have at least been deployed to staging, BUT NOT necessarily released to live.  Changes should be moved from [Unreleased] into here as they are merged into the appropriate release branch

--- a/src/Credfeto.Random.Interfaces/Credfeto.Random.Interfaces.csproj
+++ b/src/Credfeto.Random.Interfaces/Credfeto.Random.Interfaces.csproj
@@ -43,7 +43,7 @@
     <RepositoryUrl>https://github.com/credfeto/credfeto-random</RepositoryUrl>
     <RunAOTCompilation>false</RunAOTCompilation>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <TieredCompilation>true</TieredCompilation>
     <TieredPGO>true</TieredPGO>
     <TreatSpecificWarningsAsErrors />

--- a/src/Credfeto.Random.Tests/Credfeto.Random.Tests.csproj
+++ b/src/Credfeto.Random.Tests/Credfeto.Random.Tests.csproj
@@ -28,7 +28,7 @@
     <OptimizationPreference>speed</OptimizationPreference>
     <OutputType>Exe</OutputType>
     <RunAOTCompilation>false</RunAOTCompilation>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
     <TieredCompilation>true</TieredCompilation>
     <TieredPGO>true</TieredPGO>

--- a/src/Credfeto.Random/Credfeto.Random.csproj
+++ b/src/Credfeto.Random/Credfeto.Random.csproj
@@ -43,7 +43,7 @@
     <RepositoryUrl>https://github.com/credfeto/credfeto-random</RepositoryUrl>
     <RunAOTCompilation>false</RunAOTCompilation>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <TargetFramework>net10.0</TargetFramework>
     <TieredCompilation>true</TieredCompilation>
     <TieredPGO>true</TieredPGO>
     <TreatSpecificWarningsAsErrors />


### PR DESCRIPTION
## Summary
- Change `Credfeto.Random`, `Credfeto.Random.Interfaces`, and `Credfeto.Random.Tests` from `<TargetFrameworks>net9.0;net10.0</TargetFrameworks>` to a single `<TargetFramework>net10.0</TargetFramework>`.
- Add a CHANGELOG entry under `Removed`.
- No `net9.0`-specific conditional code or MSBuild conditions existed in source, so no further cleanup was needed.

Closes #63

## Test plan
- [x] `dotnet buildcheck -solution src/Credfeto.Random.slnx` passes with no errors.
- [x] `dotnet build -c Release` builds successfully, producing net10.0-only assemblies.
- [x] `dotnet test` (5 tests) passes.
- [x] Pre-commit hook (build, test, pack, changelog lint) passes on both commits.